### PR TITLE
Fix project modal positioning

### DIFF
--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -3,19 +3,22 @@ import "./style.css";
 import { AiOutlineClose } from "react-icons/ai";
 
 import { Fragment, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { ScrollSmoother } from "gsap/ScrollSmoother";
 import { useModal } from "../../contexts/modal";
 
 export default function Modal() {
   const modalRef = useRef(null);
 
-  const { 
-    modalData, 
-    toggleModal, 
-    setModalData, 
-    isModalOpen, 
-    modalTitle 
+  const {
+    modalData,
+    toggleModal,
+    setModalData,
+    isModalOpen,
+    modalTitle
   } = useModal();
 
+  // Fecha o modal ao clicar fora dele
   useEffect(() => {
     function handleClickOutside(event) {
       if (modalRef.current && !modalRef.current.contains(event.target)) {
@@ -32,9 +35,38 @@ export default function Modal() {
     };
   }, [isModalOpen, setModalData, toggleModal]);
 
+  // Fecha o modal ao pressionar a tecla Esc
+  useEffect(() => {
+    if (!isModalOpen) return;
+
+    function handleKeyDown(event) {
+      if (event.key === "Escape") {
+        toggleModal();
+        setModalData(null);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isModalOpen, setModalData, toggleModal]);
+
+  // Pausa o ScrollSmoother enquanto o modal está aberto para travar o fundo
+  useEffect(() => {
+    ScrollSmoother.get()?.paused(isModalOpen);
+
+    return () => {
+      ScrollSmoother.get()?.paused(false);
+    };
+  }, [isModalOpen]);
+
   const showClass = isModalOpen ? "show" : "hide";
-  
-  return (
+
+  // Renderiza fora do #smooth-content (que tem transform do GSAP) para que o
+  // position: fixed funcione em relação à viewport, e não ao container.
+  return createPortal(
     <Fragment>
       <div id="fade" className={`${showClass} fade`}></div>
       <div id="modal" ref={modalRef} className={showClass}>
@@ -53,6 +85,7 @@ export default function Modal() {
           {modalData}
         </div>
       </div>
-    </Fragment>
+    </Fragment>,
+    document.body
   );
 }

--- a/src/components/ProjectDetails/index.jsx
+++ b/src/components/ProjectDetails/index.jsx
@@ -8,8 +8,9 @@ import { useConfig } from "../../contexts/config";
 import { keys } from "../../locales/keys";
 
 import { Fragment, useState } from "react";
+import SkillsList from "../SkillsList";
 
-export default function ProjectDetails({  project }) {
+export default function ProjectDetails({ project }) {
   const { t } = useConfig();
 
   const projectKeys = keys.project(project?.id);
@@ -18,24 +19,8 @@ export default function ProjectDetails({  project }) {
     <Fragment>
       <div className="column project-info">
         <p className="subtitle">{t(projectKeys.subtitle)}</p>
-
-        <div className="tags">
-          {project?.skills.map((stack) => {
-            return (
-              <span className="tag" key={stack.id}>
-                {stack.icon ? (
-                  stack.icon
-                ) : (
-                  <img
-                    src={require(`../../assets/skills-logos/${stack.name.toLowerCase()}.png`)}
-                    alt={`${t("projects.tech-logo-alt")} ${stack.name}`}
-                  />
-                )}
-                {stack.name}
-              </span>
-            );
-          })}
-        </div>
+        
+        <SkillsList skills={project.skills} style="icon" keyPrefix={project.id} />
 
         <div>{t(projectKeys.description)}</div>
 


### PR DESCRIPTION
## Summary
This branch contains the full i18n refactor plus a fix for the project modal positioning.

### Modal fix
- The project modal lives inside `#smooth-content`, which GSAP ScrollSmoother transforms — making it the containing block for `position: fixed`, so the modal was centering on the whole document instead of the viewport.
- Render the modal into `document.body` via `createPortal` to escape the transform, restoring true `position: fixed` centering.
- Pause ScrollSmoother while the modal is open to lock the background; close on `Escape`.